### PR TITLE
Make "style" property optional for WMS layer

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -23,7 +23,6 @@
       "attribution": "Land NRW (2021) Deutschland – Zero – Version 2.0 (<a target='_blank' rel='noopener noreferrer' href='https://www.govdata.de/dl-de/zero-2-0'>www.govdata.de/dl-de/zero-2-0</a>)",
       "url": "https://www.wms.nrw.de/geobasis/wms_nw_dop",
       "layer": "nw_dop_rgb",
-      "style": "",
       "format": "png",
       "category": "GeoBasis NRW"
     },
@@ -32,7 +31,6 @@
       "attribution": "Land NRW (2021) Deutschland – Zero – Version 2.0 (<a target='_blank' rel='noopener noreferrer' href='https://www.govdata.de/dl-de/zero-2-0'>www.govdata.de/dl-de/zero-2-0</a>)",
       "url": "https://www.wms.nrw.de/geobasis/wms_nw_vdop",
       "layer": "nw_vdop_rgb",
-      "style": "",
       "format": "png",
       "category": "GeoBasis NRW"
     },
@@ -41,7 +39,6 @@
       "attribution": "Land NRW (2021) Deutschland – Zero – Version 2.0 (<a target='_blank' rel='noopener noreferrer' href='https://www.govdata.de/dl-de/zero-2-0'>www.govdata.de/dl-de/zero-2-0</a>)",
       "url": "https://www.wms.nrw.de/geobasis/wms_nw_alkis",
       "layer": "adv_alkis_flurstuecke",
-      "style": "",
       "format": "png",
       "category": "GeoBasis NRW"
     },
@@ -50,7 +47,6 @@
       "attribution": "Land NRW (2021) Deutschland – Zero – Version 2.0 (<a target='_blank' rel='noopener noreferrer' href='https://www.govdata.de/dl-de/zero-2-0'>www.govdata.de/dl-de/zero-2-0</a>)",
       "url": "https://www.wms.nrw.de/geobasis/wms_nw_abk",
       "layer": "WMS_NW_ABK",
-      "style": "",
       "format": "png",
       "category": "GeoBasis NRW"
     },
@@ -59,7 +55,6 @@
       "attribution": "Land NRW (2021) Deutschland – Zero – Version 2.0 (<a target='_blank' rel='noopener noreferrer' href='https://www.govdata.de/dl-de/zero-2-0'>www.govdata.de/dl-de/zero-2-0</a>)",
       "url": "https://www.wms.nrw.de/geobasis/wms_nw_alkis",
       "layer": "adv_alkis_tatsaechliche_nutzung",
-      "style": "Farbe",
       "format": "png",
       "category": "GeoBasis NRW"
     },
@@ -68,7 +63,6 @@
       "attribution": "Land NRW (2021) Deutschland – Zero – Version 2.0 (<a target='_blank' rel='noopener noreferrer' href='https://www.govdata.de/dl-de/zero-2-0'>www.govdata.de/dl-de/zero-2-0</a>)",
       "url": "https://www.wms.nrw.de/geobasis/wms_nw_dgm-schummerung",
       "layer": "nw_dgm-schummerung_pan",
-      "style": "",
       "format": "png",
       "category": "GeoBasis NRW"
     },
@@ -77,7 +71,6 @@
       "attribution": "Land NRW (2021) Deutschland – Zero – Version 2.0 (<a target='_blank' rel='noopener noreferrer' href='https://www.govdata.de/dl-de/zero-2-0'>www.govdata.de/dl-de/zero-2-0</a>)",
       "url": "https://www.wms.nrw.de/geobasis/wms_nw_dtk",
       "layer": "nw_dtk_col",
-      "style": "",
       "format": "png",
       "category": "GeoBasis NRW"
     },
@@ -86,7 +79,6 @@
       "attribution": "Land NRW (2021) Deutschland – Zero – Version 2.0 (<a target='_blank' rel='noopener noreferrer' href='https://www.govdata.de/dl-de/zero-2-0'>www.govdata.de/dl-de/zero-2-0</a>)",
       "url": "https://www.wms.nrw.de/geobasis/wms_nw_dop_overlay",
       "layer": "WMS_NW_DOP_OVERLAY",
-      "style": "",
       "format": "png",
       "category": "GeoBasis NRW",
       "onlyOverlay": true
@@ -96,7 +88,6 @@
       "attribution": "Land NRW (2021) Deutschland – Zero – Version 2.0 (<a target='_blank' rel='noopener noreferrer' href='https://www.govdata.de/dl-de/zero-2-0'>www.govdata.de/dl-de/zero-2-0</a>)",
       "url": "https://www.wms.nrw.de/umwelt/linfos",
       "layer": "Naturschutzgebiete,Landschaftsschutzgebiet",
-      "style": "",
       "format": "png",
       "category": "GeoBasis NRW",
       "onlyOverlay": true
@@ -112,7 +103,6 @@
       "attribution": "<a target='_blank' rel='noopener noreferrer' href='https://www.rvr.ruhr/daten-digitales/geodaten/luftbilder/'>Regionalverband Ruhr</a>",
       "url": "https://geodaten.metropoleruhr.de/dop/dop?language=ger&",
       "layer": "dop",
-      "style": "",
       "format": "png",
       "category": "RVR"
     },
@@ -121,7 +111,6 @@
       "attribution": "Land NRW (2021) Deutschland – Zero – Version 2.0 (<a target='_blank' rel='noopener noreferrer' href='https://www.govdata.de/dl-de/zero-2-0'>www.govdata.de/dl-de/zero-2-0</a>)",
       "url": "https://gdi-niederrhein-geodienste.de/flurkarte_verb_sammeldienst/service",
       "layer": "FlurkarteAdV_Viersen",
-      "style": "",
       "format": "png",
       "category": "KRZN-Dienste"
     },
@@ -130,7 +119,6 @@
       "attribution": "Land NRW (2021) Deutschland – Zero – Version 2.0 (<a target='_blank' rel='noopener noreferrer' href='https://www.govdata.de/dl-de/zero-2-0'>www.govdata.de/dl-de/zero-2-0</a>)",
       "url": "https://gdi-niederrhein-geodienste.de/flurkarte_verb_sammeldienst/service",
       "layer": "FlurkarteAdV_Krefeld",
-      "style": "",
       "format": "png",
       "category": "KRZN-Dienste"
     },
@@ -139,7 +127,6 @@
       "attribution": "Land NRW (2021) Deutschland – Zero – Version 2.0 (<a target='_blank' rel='noopener noreferrer' href='https://www.govdata.de/dl-de/zero-2-0'>www.govdata.de/dl-de/zero-2-0</a>)",
       "url": "https://gdi-niederrhein-geodienste.de/flurkarte_verb_sammeldienst/service",
       "layer": "FlurkarteAdV_Wesel",
-      "style": "",
       "format": "png",
       "category": "KRZN-Dienste"
     },
@@ -148,7 +135,6 @@
       "attribution": "Land NRW (2021) Deutschland – Zero – Version 2.0 (<a target='_blank' rel='noopener noreferrer' href='https://www.govdata.de/dl-de/zero-2-0'>www.govdata.de/dl-de/zero-2-0</a>)",
       "url": "https://gdi-niederrhein-geodienste.de/flurkarte_verb_sammeldienst/service",
       "layer": "FlurkarteAdV_Kleve",
-      "style": "",
       "format": "png",
       "category": "KRZN-Dienste"
     },
@@ -157,7 +143,6 @@
       "attribution": "Land NRW (2021) Deutschland – Zero – Version 2.0 (<a target='_blank' rel='noopener noreferrer' href='https://www.govdata.de/dl-de/zero-2-0'>www.govdata.de/dl-de/zero-2-0</a>)",
       "url": "https://gdi-niederrhein-geodienste.de/flurkarte_verb_sammeldienst/service",
       "layer": "Flurkarte_Bottrop",
-      "style": "",
       "format": "png",
       "category": "KRZN-Dienste"
     },
@@ -166,7 +151,6 @@
       "attribution": "Land NRW (2021) Deutschland – Zero – Version 2.0 (<a target='_blank' rel='noopener noreferrer' href='https://www.govdata.de/dl-de/zero-2-0'>www.govdata.de/dl-de/zero-2-0</a>)",
       "url": "https://geoservices.krzn.de/security-proxy/services/wms_kvie_alkis_light",
       "layer": "nutzungsarten,flurstuecke,gebaeude,lagebezeichnungen",
-      "style": "",
       "format": "png",
       "category": "KRZN-Dienste"
     },
@@ -175,7 +159,6 @@
       "attribution": "Land NRW (2021) Deutschland – Zero – Version 2.0 (<a target='_blank' rel='noopener noreferrer' href='https://www.govdata.de/dl-de/zero-2-0'>www.govdata.de/dl-de/zero-2-0</a>)",
       "url": "https://geoservices.krzn.de/security-proxy/services/wms_kvie_geplgeb",
       "layer": "kvie_geplgeb",
-      "style": "",
       "format": "png",
       "category": "Nationaal Georegister (NL)"
     },
@@ -184,7 +167,6 @@
       "attribution": "<a target='_blank' rel='noopener noreferrer' href='http://geodata.nationaalgeoregister.nl'>Nationaal Georegister</a>",
       "url": "https://geodata.nationaalgeoregister.nl/luchtfoto/rgb/wms",
       "layer": "Actueel_ortho25",
-      "style": "",
       "format": "jpeg",
       "category": "KRZN-Dienste"
     },
@@ -193,7 +175,6 @@
       "attribution": "<a target='_blank' rel='noopener noreferrer' href='https://www.kreis-warendorf.de/arcgis/service2?SERVICE=WMS&REQUEST=GetCapabilities'>Geodaten: Kreis Warendorf</a>",
       "url": "https://www.kreis-warendorf.de/arcgis/service2",
       "layer": "alkis_lieka",
-      "style": "",
       "format": "png",
       "category": "Kreis Warendorf"
     },
@@ -202,7 +183,6 @@
       "attribution": "<a target='_blank' rel='noopener noreferrer' href='https://www.kreis-warendorf.de/arcgis/service2?SERVICE=WMS&REQUEST=GetCapabilities'>Geodaten: Kreis Warendorf</a>",
       "url": "https://www.kreis-warendorf.de/arcgis/service2",
       "layer": "abk5000",
-      "style": "",
       "format": "png",
       "category": "Kreis Warendorf"
     }

--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,9 @@ config.layer.forEach(function(item) {
     if (item.url == "https://tile.openstreetmap.org/{z}/{x}/{y}.png") {
       default_style.sources[item.name].tiles = [item.url];
     } else {
+      if (!item.style){
+        item.style = "";
+      }
       default_style.sources[item.name].tiles = [item.url + "?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS=EPSG:3857&BBOX={bbox-epsg-3857}&WIDTH=256&HEIGHT=256&LAYERS=" + item.layer + "&STYLES=" + item.style + "&FORMAT=image/" + item.format];
     }
     default_style.sources[item.name].tileSize = 256;
@@ -144,6 +147,9 @@ config.layer.forEach(function(item) {
   if (item.url == "https://tile.openstreetmap.org/{z}/{x}/{y}.png") {
     default_style.sources[overlay_id].tiles = [item.url];
   } else {
+    if (!item.style){
+      item.style = "";
+    }
     default_style.sources[overlay_id].tiles = [item.url + "?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS=EPSG:3857&BBOX={bbox-epsg-3857}&WIDTH=256&HEIGHT=256&LAYERS=" + item.layer + "&STYLES=" + item.style + "&FORMAT=image/" + item.format + "&TRANSPARENT=true"];
   }
   default_style.sources[overlay_id].tileSize = 256;

--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ config.layer.forEach(function(item) {
     if (item.url == "https://tile.openstreetmap.org/{z}/{x}/{y}.png") {
       default_style.sources[item.name].tiles = [item.url];
     } else {
-      if (!item.style){
+      if (!item.style) {
         item.style = "";
       }
       default_style.sources[item.name].tiles = [item.url + "?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS=EPSG:3857&BBOX={bbox-epsg-3857}&WIDTH=256&HEIGHT=256&LAYERS=" + item.layer + "&STYLES=" + item.style + "&FORMAT=image/" + item.format];
@@ -147,7 +147,7 @@ config.layer.forEach(function(item) {
   if (item.url == "https://tile.openstreetmap.org/{z}/{x}/{y}.png") {
     default_style.sources[overlay_id].tiles = [item.url];
   } else {
-    if (!item.style){
+    if (!item.style) {
       item.style = "";
     }
     default_style.sources[overlay_id].tiles = [item.url + "?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS=EPSG:3857&BBOX={bbox-epsg-3857}&WIDTH=256&HEIGHT=256&LAYERS=" + item.layer + "&STYLES=" + item.style + "&FORMAT=image/" + item.format + "&TRANSPARENT=true"];


### PR DESCRIPTION
Looks like most of the time the default style of a WMS is used (at least for the currently used services).

So we are making the `style` property optional, to keep the config simple.